### PR TITLE
[FIX] 알람에 is_deleted추가 및 soft delete 칼럼 변경 (is_activated-> is_deleted)

### DIFF
--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/model/Alarm.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/model/Alarm.java
@@ -4,6 +4,7 @@ import com.wakeUpTogetUp.togetUp.api.mission.model.Mission;
 import com.wakeUpTogetUp.togetUp.api.mission.model.MissionObject;
 import com.wakeUpTogetUp.togetUp.api.room.model.Room;
 import com.wakeUpTogetUp.togetUp.api.users.model.User;
+
 import java.time.DayOfWeek;
 import java.time.LocalTime;
 import java.util.Objects;
@@ -17,6 +18,7 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.OneToOne;
 import javax.persistence.Table;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -28,8 +30,8 @@ import org.hibernate.annotations.Where;
 
 @ToString
 @Entity
-@SQLDelete(sql = "UPDATE alarm SET is_activated = false WHERE id = ?")
-@Where(clause = "is_activated = true")
+@SQLDelete(sql = "UPDATE alarm SET is_deleted = true WHERE id = ?")
+@Where(clause = "is_deleted = false")
 @Table(name = "alarm")
 @DynamicInsert
 @Data
@@ -67,6 +69,7 @@ public class Alarm {
     private Boolean isSnoozeActivated;
     private Boolean isVibrate;
     private Boolean isActivated;
+    private Boolean isDeleted;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", columnDefinition = "INT UNSIGNED")
@@ -105,6 +108,7 @@ public class Alarm {
         setIsVibrate(isVibrate);
         setIsSnoozeActivated(isSnoozeActivated);
         setIsActivated(isActivated);
+        setIsDeleted(false);
         setMission(mission);
         setMissionObject(missionObject);
     }

--- a/src/main/resources/migration/updates/20240402[alarm].sql
+++ b/src/main/resources/migration/updates/20240402[alarm].sql
@@ -1,0 +1,2 @@
+alter table alarm
+    add is_deleted tinyint(1) default 0 not null;


### PR DESCRIPTION
## ☀️ 작업 사항
- 알람에 is_deleted 칼럼을 추가했습니다.
- soft delete 를 적용했던 칼럼을 is_activied에서 is_deleted로 변경헀습니다.
## ☀️ 관련 이슈


## ☀️ 참고 사항
- 알람 삭제api가 있기 때문에 dto에서 값을 안 받아도 될것 같아서, alarm 클래스의 modifyProperties함수에 setIsDeleted(false);를 추가했습니다.  빨리 수정해야해서 임시로 한 것이기 때문에 나중에 수정해주셔도 됩니다.

