### PR TITLE
[FIX] 애플로그인 수정, 이메일 길이 수정

### DIFF
--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/auth/service/AppleLoginServiceImpl.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/auth/service/AppleLoginServiceImpl.java
@@ -74,9 +74,9 @@ public class AppleLoginServiceImpl implements SocialLoginService {
         Claims claims = appleJwtParser.parsePublicKeyAndGetClaims(accessToken, publicKey);
 
         validateClaims(claims);
-        String sanitizedEmail = sanitizeEmail(claims.get("email", String.class));
+        String filteredEmail = filterPrivateEmail(claims.get("email", String.class));
 
-        AppleLoginRes appleLoginRes = new AppleLoginRes(claims.getSubject(), sanitizedEmail);
+        AppleLoginRes appleLoginRes = new AppleLoginRes(claims.getSubject(), filteredEmail);
 
         return SocialUserRes.builder()
                 .id(appleLoginRes.getId())
@@ -91,7 +91,7 @@ public class AppleLoginServiceImpl implements SocialLoginService {
         }
     }
 
-    private String sanitizeEmail(String email) {
+    private String filterPrivateEmail(String email) {
         return (email != null && email.endsWith(APPLE_PRIVATE_RELAY_DOMAIN)) ? "" : email;
     }
 

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/auth/service/AuthService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/auth/service/AuthService.java
@@ -50,7 +50,7 @@ public class AuthService {
 
         return LoginRes.builder()
                 .userId(user.getId())
-                .userName(socialUserRes.getName())
+                .userName(user.getName())
                 .email(socialUserRes.getEmail())
                 .accessToken(accessToken)
                 .avatarId(userAvatarService.getUserAvatarId(user.getId()))

--- a/src/main/resources/migration/togetup-erd.sql
+++ b/src/main/resources/migration/togetup-erd.sql
@@ -64,7 +64,7 @@ create table user
     id         int unsigned auto_increment
         primary key,
     name       varchar(10)                            null,
-    email      varchar(30)                            null,
+    email      varchar(320)                            null,
     login_type varchar(20)                            not null,
     social_id  varchar(80)                            not null,
     agree_push tinyint(1)   default 1                 not null,
@@ -94,6 +94,7 @@ create table alarm
     is_snooze_activated tinyint(1)  default 1   not null,
     is_vibrate          tinyint(1)  default 1   not null,
     is_activated        tinyint(1)  default 1   not null,
+    is_deleted          tinyint(1)  default 0   not null
     user_id             int unsigned            null,
     mission_id          int unsigned            not null,
     mission_object_id   int unsigned            null,
@@ -151,7 +152,6 @@ create table room_user
     created_at timestamp  default CURRENT_TIMESTAMP not null,
     room_id    int unsigned                         null,
     user_id    int unsigned                         not null,
-    is_host    tinyint(1) default 0                 null,
     agree_push tinyint(1) default 1                 null,
     constraint room_user_ibfk_1
         foreign key (room_id) references room (id),

--- a/src/main/resources/migration/updates/20240405[user].sql
+++ b/src/main/resources/migration/updates/20240405[user].sql
@@ -1,0 +1,2 @@
+alter table user
+    modify email varchar(30) null;

--- a/src/main/resources/migration/updates/20240405[user].sql
+++ b/src/main/resources/migration/updates/20240405[user].sql
@@ -1,2 +1,2 @@
 alter table user
-    modify email varchar(30) null;
+    modify email varchar(320) null;


### PR DESCRIPTION
## ☀️ 작업 사항
- 이메일 길이를 수정했습니다.
- 암호화된 이메일일 경우 빈 문자열로 db에 저장하게 수정했습니다.
- 로그인 응답의 유저 이름을 db에서 가져오게 수정했습니다. (원래는 요청 dto에서 가져왔습니다.)

## ☀️ 참고 사항
이메일 칼럼 수정되었습니다. 
지난 변경들도 ddl에 반영했습니다.

애플로그인 할 때 이메일 가리기를 할 경우 암호화된 이메일이 길어가 길어서 db에서 이메일 길이로 에러가 나기 때문에
개발 db에 이메일 길이 미리 수정해놓았습니다.