### PR TITLE
[ENV] CI workflow application.yml 파일 생성 에러 해결

### DIFF
--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+          echo '${{ secrets.TOGETUP_DEV_APPLICATION }}' > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
         shell: bash
 

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -25,10 +25,9 @@ jobs:
 
       - name: make application.yml
         run: |
-          cd ./src/main/resources
-          touch ./application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./application.yml
-          cat ./application.yml
+          touch ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+          cat ./src/main/resources/application.yml
         shell: bash
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -24,12 +24,10 @@ jobs:
           distribution: 'temurin'
 
       - name: make application.yml
-        uses: actions/checkout@v3
         run: |
-          mkdir -p ./src/main/resources
           cd ./src/main/resources
           touch ./application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./application.yml
           cat ./application.yml
         shell: bash
 

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -23,11 +23,12 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - uses : actions/checkout@v3
-      - run: touch ./src/main/resources/application.yml
-      - run: echo ${{ secrets.TOGETUP_DEV_APPLICATION }}
-      - run: echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
-      - run: cat ./src/main/resources/application.yml
+      - name: make application.yml
+        run: |
+          touch ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+          cat ./src/main/resources/application.yml
+        shell: bash
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -25,7 +25,8 @@ jobs:
 
       - uses : actions/checkout@v3
       - run: touch ./src/main/resources/application.yml
-      - run: echo "${{ secrets.TOGETUP_DEV_APPLICAION }}" > ./src/main/resources/application.yml
+      - run: echo ${{ secrets.TOGETUP_DEV_APPLICATION }}
+      - run: echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
       - run: cat ./src/main/resources/application.yml
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -25,7 +25,6 @@ jobs:
 
       - name: make application.yml
         run: |
-          mkdir -p ./src/main/resources
           cd ./src/main/resources
           touch ./application.yml
           echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./application.yml

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo 'hello' > ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
         shell: bash
 

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -23,12 +23,10 @@ jobs:
           java-version: '11'
           distribution: 'temurin'
 
-      - name: make application.yml
-        run: |
-          touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
-          cat ./src/main/resources/application.yml
-        shell: bash
+      - uses : actions/checkout@v3
+      - run: touch ./src/main/resources/application.yml
+      - run: echo "${{ secrets.TOGETUP_DEV_APPLICAION }}" > ./src/main/resources/application.yml
+      - run: cat ./src/main/resources/application.yml
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./src/main/resources/application.yml
         shell: bash
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -27,7 +27,6 @@ jobs:
         run: |
           touch ./src/main/resources/application.yml
           echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
-          cat ./src/main/resources/application.yml
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -28,7 +28,6 @@ jobs:
           touch ./src/main/resources/application.yml
           echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
-        shell: bash
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,8 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+#          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+          echo 'hello' > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
         shell: bash
 

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -27,6 +27,7 @@ jobs:
         run: |
           touch ./src/main/resources/application.yml
           echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+        shell: bash
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -24,9 +24,11 @@ jobs:
           distribution: 'temurin'
 
       - name: make application.yml
+        env:
+          APPLICATION: ${{ secrets.TOGETUP_DEV_APPLICATION }}
         run: |
           touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+          echo "$APPLICATION" > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,6 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-#          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
           echo 'hello' > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
         shell: bash

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ "main" ]
   push:
-    branches: [ "main", "env/fix_ci" ]
+    branches: [ "main" ]
 
 permissions:
   contents: read

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -33,4 +33,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build -x test
+        run: ./gradlew build

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./src/main/resources/application.yml
+          echo '${{ secrets.TOGETUP_DEV_APPLICATION }}' > ./src/main/resources/application.yml
         shell: bash
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo ${{ secrets.TOGETUP_DEV_APPLICATION }} >> ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
         shell: bash
 

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -33,4 +33,4 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew clean build

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo '${{ secrets.TOGETUP_DEV_APPLICATION }}' > ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
         shell: bash
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo '${{ secrets.TOGETUP_DEV_APPLICATION }}' > ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
         shell: bash
 

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
+          echo '${{ secrets.TOGETUP_DEV_APPLICATION }}' > ./src/main/resources/application.yml
         shell: bash
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -24,11 +24,9 @@ jobs:
           distribution: 'temurin'
 
       - name: make application.yml
-        env:
-          APPLICATION: ${{ secrets.TOGETUP_DEV_APPLICATION }}
         run: |
           touch ./src/main/resources/application.yml
-          echo "$APPLICATION" > ./src/main/resources/application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" > ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
 
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [ "main" ]
   push:
-    branches: [ "main", "env/CICD" ]
+    branches: [ "main", "env/fix_ci" ]
 
 permissions:
   contents: read
@@ -13,29 +13,28 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    
-    - name: checkout
-      uses: actions/checkout@v3
 
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
-    
-    - name: make application.properties
-      run: |
-        ## create application.yml
-        mkdir -p ./src/main/resources
-        cd ./src/main/resources
-        touch ./application.yaml
-        echo "${{ secrets.TOGETUP_PROD_APPLICATION }}" >> ./application.yaml
-        cat ./application.yaml
-      shell: bash
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: make application.yml
+        run: |
+          mkdir -p ./src/main/resources
+          cd ./src/main/resources
+          touch ./application.yml
+          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./application.yml
+          cat ./application.yml
+        shell: bash
 
 
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-      
-    - name: Build with Gradle
-      run: ./gradlew build -x test
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build -x test

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -26,7 +26,7 @@ jobs:
       - name: make application.yml
         run: |
           touch ./src/main/resources/application.yml
-          echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./src/main/resources/application.yml
+          echo ${{ secrets.TOGETUP_DEV_APPLICATION }} >> ./src/main/resources/application.yml
           cat ./src/main/resources/application.yml
         shell: bash
 

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -24,13 +24,14 @@ jobs:
           distribution: 'temurin'
 
       - name: make application.yml
+        uses: actions/checkout@v3
         run: |
+          mkdir -p ./src/main/resources
           cd ./src/main/resources
           touch ./application.yml
           echo "${{ secrets.TOGETUP_DEV_APPLICATION }}" >> ./application.yml
           cat ./application.yml
         shell: bash
-
 
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew


### PR DESCRIPTION
## ☀️ 작업 사항

- CI workflow에서 application.yml 파일 생성 시 생기는 에러를 해결했습니다.

## ☀️ 참고 사항

에러의 원인은 echo로 내용을 복사할 때 github secret을 ""에 감싸느냐, ''에 감싸느냐의 차이였는데 사실 ""의 경우 정확히 왜 안되는건지는 아직 찾지 못했습니다.

다른 예시들을 참고했을 때는 ""를 사용하던데 이후에 더 알아보려 합니다.

추가)

말씀해주신 내용 바탕으로 yml 파일 내부에 특수문자를 제거하였습니다.
저희 설정 파일에 

``` yaml
      jdbc-url: ${spring.datasource.url}
      username: ${spring.datasource.username}
      password: ${spring.datasource.password}
      driver-class-name: ${spring.datasource.driver-class-name}
```

위 부분의 특수문자를 삭제하니 제대로 작동합니다!

"" 내부에(application.yml의 내용) ${} 가 있으면 해당 변수를 환경 변수에서 찾아서 치환하려고 하기 때문에 에러가 발생하는 것 같습니다.

만약 저희가 시스템 내부의 환경 변수를 설정하여 사용하는 방법을 쓰고 있다면 " "를 사용하는 것이 바람직하지만, 지금의 상황에서는 그냥 값만 받아도 충분할 것 같아 최종적으로는 ' '로 변경하겠습니다!

이에 대해서 의견이 있다면 추가로 남겨주시면 좋을 것 같습니다.