### PR TITLE
[FEATURE] 미션 수행 API 처리율 제한 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -123,6 +123,15 @@ dependencies {
     // firebase admin 종속성에서 api-client 2.2.0 버전을 사용해서 버전 충돌이 났음
     implementation 'com.google.api-client:google-api-client:1.31.1'
     implementation 'com.google.cloud:google-cloud-storage:1.113.6'
+
+    // cache
+    implementation 'org.springframework.boot:spring-boot-starter-cache'
+    implementation 'javax.cache:cache-api'
+
+    // bucket4j
+    implementation 'com.giffing.bucket4j.spring.boot.starter:bucket4j-spring-boot-starter:0.8.1'
+    implementation 'com.github.ben-manes.caffeine:caffeine'
+    implementation 'com.github.ben-manes.caffeine:jcache'
 }
 
 def querydslDir = "$buildDir/generated/querydsl"

--- a/src/main/java/com/wakeUpTogetUp/togetUp/TogetUpApplication.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/TogetUpApplication.java
@@ -2,12 +2,14 @@ package com.wakeUpTogetUp.togetUp;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
 
 @EnableFeignClients
 @EnableAspectJAutoProxy(proxyTargetClass = true)
 @SpringBootApplication
+@EnableCaching
 public class TogetUpApplication {
 
     static {

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/strategy/MissionImageStrategyFactory.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/strategy/MissionImageStrategyFactory.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Component;
 public class MissionImageStrategyFactory {
 
     private final SimpleConversionStrategy simpleConversionStrategy;
-    private final AnalysisConversionStrategy imageProcessingStrategy;
+    private final AnalysisConversionStrategy analysisConversionStrategy;
 
     public MissionImageStrategy getStrategy(MissionType missionType) {
         switch (missionType) {
@@ -18,7 +18,7 @@ public class MissionImageStrategyFactory {
                 return simpleConversionStrategy;
 
             default:
-                return imageProcessingStrategy;
+                return analysisConversionStrategy;
         }
     }
 }


### PR DESCRIPTION
## ☀️ 작업 사항

외부 API와 연결되어 있는 미션 수행 API의 처리율 제한을 구현했습니다.

## ☀️ 참고 사항

bucket4j-spring-boot-starter을 사용하여 자세한 설정은 스프링부트 yml 설정 파일에 작성하였습니다. 설정파일이 지금 레포에 올라가 있지 않아 코드로 공유합니다.
이후로는 중요 환경 변수들을 properties 파일로 따로 관리하고, yml 설정 파일을 형상 관리하는 쪽으로 수정하면 더 좋을 것 같습니다! 제가 해도 좋고, 관심있으시다면 직접 해주셔도 좋을 것 같습니다!

``` yaml
bucket4j:
  enabled: true
  filters:
    - cache-name: mission-rate-limit-buckets
      url: ^/app/mission/([^/]+)/result$
      strategy: first
      http-response-body: "{ \"httpStatusCode\": 429, \"httpReasonPhrase\": \"Too Many Requests\", \"message\": \"You have exhausted your API Request Quota.\" }"
      rate-limits:
        - cache-key: "getHeader('Authorization')"
          execute-condition: "getHeader('Authorization') != null"
          bandwidths:
            - capacity: 5
              time: 1
              unit: minutes
              refill-speed: interval
```

기본적인 설정은 1분에 토큰 5개를 제공하고, 고정된 시간에 고정된 양의 토큰만 사용할 수 있도록 구현하였습니다.

알람은 1분에 한번만 울리기 때문에 알람 1번에 요청 횟수를 5번으로 제한한다는 의미로 위와 같이 구현하였는데 이에 대한 의견이 궁금합니다!

[요청이 성공적으로 처리된 경우]
![image](https://github.com/Wake-up-together-TogetUp/togetup-server/assets/83827023/02c7b711-f672-4ede-9845-2add2b373c01)
헤더에 `x-rate-limit-remaining`의 값을 통해서 몇개의 토큰이 남았는지 확인할 수 있고

[토큰이 없어 요청이 거부된 경우]
![image](https://github.com/Wake-up-together-TogetUp/togetup-server/assets/83827023/2984eb26-303a-436d-a317-1d3766412d15)
![image](https://github.com/Wake-up-together-TogetUp/togetup-server/assets/83827023/e7b37935-da81-4d91-a856-0d6caa3c145d)
위와 같이 토큰이 소진됐다는 메시지와 함께 헤더에 `x-rate-limit-retry-after-seconds`이 토큰이 충전될 때까지 남은 시간을 알려줍니다.

[레포 링크]
https://github.com/MarcGiffing/bucket4j-spring-boot-starter

[참고 자료]
https://www.baeldung.com/spring-bucket4j