### PR TITLE
[FEATURE] 그룹 인원 제한 락 구현

### DIFF
--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomRepository.java
@@ -19,7 +19,6 @@ public interface RoomRepository extends JpaRepository<Room, Integer> {
 
     @Query("SELECT r FROM Room r JOIN Alarm a ON r.id = a.room.id WHERE a.id= :alarmId")
     Optional<Room> findByAlarmId(@Param("alarmId") Integer alarmId);
-    Optional<Room> findByInvitationCode(@Param("invitationCode") String invitationCode);
 
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @QueryHints({

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomRepository.java
@@ -3,11 +3,15 @@ package com.wakeUpTogetUp.togetUp.api.room;
 
 import com.wakeUpTogetUp.togetUp.api.room.dto.response.RoomDetailRes;
 import com.wakeUpTogetUp.togetUp.api.room.model.Room;
+import org.springframework.data.jpa.repository.Lock;
+import org.springframework.data.jpa.repository.QueryHints;
 import org.springframework.data.repository.query.Param;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
+import javax.persistence.LockModeType;
+import javax.persistence.QueryHint;
 import java.util.Optional;
 
 @Repository
@@ -17,5 +21,11 @@ public interface RoomRepository extends JpaRepository<Room, Integer> {
     Optional<Room> findByAlarmId(@Param("alarmId") Integer alarmId);
     Optional<Room> findByInvitationCode(@Param("invitationCode") String invitationCode);
 
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @QueryHints({
+            @QueryHint(name = "jakarta.persistence.lock.timeout", value = "10000")
+    })
+    @Query("SELECT r FROM Room r where r.id = :id ")
+    Optional<Room> findByIdUsingPessimisticLock(@Param("id") Integer id);
 
 }

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomUserRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomUserRepository.java
@@ -13,28 +13,10 @@ import java.util.Optional;
 @Repository
 public interface RoomUserRepository extends JpaRepository<RoomUser, Integer> {
 
-    List<RoomUser> findByUserId(Integer userId);
 
-    @Query("SELECT ru FROM RoomUser ru " +
-            "JOIN User u ON (ru.user.id = u.id) " +
-            "WHERE ru.room.id = :roomId " +
-            "ORDER BY " +
-            "CASE WHEN ru.user.id = :userId THEN 0 " +
-            "ELSE 1 " +
-            "END, u.name")
-
-    List<RoomUser> findAllByRoom_IdOrderByPreference(Integer roomId, Integer userId);
-
-
-    @Query("SELECT ru.room.id " +
-            "FROM RoomUser ru " +
-            "WHERE ru.user.id = :userId " +
-            "ORDER BY ru.createdAt DESC")
-    List<Integer> findAllRoomIdsByUserId(@Param("userId") Integer userId);
 
     Integer countByUserId(Integer userId);
 
-    Integer countByRoomId(Integer roomId);
 
     void deleteByUserId(Integer userId);
 
@@ -42,11 +24,8 @@ public interface RoomUserRepository extends JpaRepository<RoomUser, Integer> {
 
 
 
-    boolean existsRoomUserByRoom_IdAndUser_Id(Integer roomId, Integer userId);
 
-    void deleteByRoom_IdAndUser_Id(Integer roomId, Integer userId);
 
-    List<RoomUser> findAllByRoom_IdOrderByCreatedAt(Integer roomId);
 
 
 }

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/model/Room.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/model/Room.java
@@ -1,7 +1,6 @@
 package com.wakeUpTogetUp.togetUp.api.room.model;
 
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.common.Constant;
 import com.wakeUpTogetUp.togetUp.common.Status;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/common/Status.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/common/Status.java
@@ -70,6 +70,7 @@ public enum Status {
     USER_AVATAR_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 보유한 아바타 입니다."),
     ROOM_USER_ALREADY_EXIST(HttpStatus.CONFLICT, "이미 방에 들어간 멤버입니다."),
     USER_AVATAR_NOT_ACTIVE(HttpStatus.CONFLICT, "현재 활성화된 유저 아바타가 아닙니다."),
+    ROOM_FULL(HttpStatus.CONFLICT,"방의 인원이 전부 찼습니다. "),
 
     // UNSUPPORTED MEDIA TYPE
     UNSUPPORTED_MEDIA_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "지원하지 않는 파일 확장자 입니다."),


### PR DESCRIPTION
## ☀️ 작업 사항
- `Pessimistic Lock`을 사용해 그룹에 10명 인원 제한을 구현
- Room 객체의 cascade 및 고아 객체 제거 설정 추가
- Room 엔티티의 비지니스 로직을 서비스 계층에서 도메인 계층으로 기능 이동

## ☀️ 참고 사항
