### PR TITLE
[FEAT] 알람 icon을 미션 icon으로 대체

### DIFF
--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/AlarmController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/AlarmController.java
@@ -3,7 +3,7 @@ package com.wakeUpTogetUp.togetUp.api.alarm;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.AlarmsDeactivateReq;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PatchAlarmReq;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PostAlarmReq;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.GetAlarmRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmDetailRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmQueryService;
 import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmService;
 import com.wakeUpTogetUp.togetUp.api.auth.AuthUser;
@@ -43,10 +43,10 @@ public class AlarmController {
             @ApiResponse(
                     responseCode = "200",
                     description = "요청에 성공하였습니다.",
-                    content = @Content(schema = @Schema(implementation = GetAlarmRes.class))),
+                    content = @Content(schema = @Schema(implementation = AlarmDetailRes.class))),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 알람 입니다.")})
     @GetMapping("/{alarmId}")
-    public BaseResponse<GetAlarmRes> getAlarm(@PathVariable Integer alarmId) {
+    public BaseResponse<AlarmDetailRes> getAlarm(@PathVariable Integer alarmId) {
         return new BaseResponse<>(Status.SUCCESS, alarmQueryService.getAlarmById(alarmId));
     }
 
@@ -55,11 +55,11 @@ public class AlarmController {
             @ApiResponse(
                     responseCode = "200",
                     description = "요청에 성공하였습니다.",
-                    content = @Content(schema = @Schema(implementation = GetAlarmRes.class))),
+                    content = @Content(schema = @Schema(implementation = AlarmDetailRes.class))),
             @ApiResponse(responseCode = "400", description = "요청 파라미터를 확인해주세요."),
             @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 입니다.")})
     @GetMapping
-    public BaseResponse<List<GetAlarmRes>> getAlarmsByUserId(
+    public BaseResponse<List<AlarmDetailRes>> getAlarmsByUserId(
             @Parameter(description = "- 개인 : personal\n- 그룹 : group", example = "personal") String type,
             @Parameter(hidden = true) @AuthUser Integer userId
     ) {

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/AlarmController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/AlarmController.java
@@ -83,7 +83,7 @@ public class AlarmController {
             @Parameter(hidden = true) @AuthUser Integer userId,
             @RequestBody @Valid PostAlarmReq postAlarmReq
     ) {
-        return new BaseResponse<>(Status.SUCCESS_CREATED, alarmService.createAlarmDeprecated(userId, postAlarmReq).getId());
+        return new BaseResponse<>(Status.SUCCESS_CREATED, alarmService.create(userId, postAlarmReq).getId());
     }
 
     @Operation(summary = "알람 수정")

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/request/PatchAlarmReq.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/request/PatchAlarmReq.java
@@ -3,7 +3,11 @@ package com.wakeUpTogetUp.togetUp.api.alarm.dto.request;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import lombok.*;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Getter
 @Setter
@@ -13,10 +17,6 @@ public class PatchAlarmReq {
     @Schema(description = "알람 이름", example = "기상 알람")
     @NotNull(message = "null 값일 수 없습니다.")
     private String name;
-
-    @Schema(description = "아이콘", example = "⏰")
-    @NotNull(message = "null 값일 수 없습니다.")
-    private String icon;
 
     @Schema(description = "알람 시간", example = "06:00")
     @NotNull(message = "null 값일 수 없습니다.")

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/request/PostAlarmReq.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/request/PostAlarmReq.java
@@ -5,7 +5,6 @@ import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -20,9 +19,6 @@ public class PostAlarmReq {
     @Schema(description = "알람 이름", requiredMode = RequiredMode.REQUIRED, example = "기상")
     @NotBlank(message = "알람 이름은 공백일 수 없습니다.")
     private String name;
-
-    @Schema(description = "아이콘", defaultValue = "⏰", example = "⏰")
-    private String icon;
 
     @Schema(description = "알람 시간", requiredMode = RequiredMode.REQUIRED, example = "06:00")
     @NotNull(message = "알람 시간은 공백일 수 없습니다.")

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/response/AlarmDetailRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/response/AlarmDetailRes.java
@@ -10,12 +10,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Schema(description = "알람 1개 가져오기 response")
+@Schema(description = "알람 상세 조회 response")
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetAlarmRes {
+public class AlarmDetailRes {
     @Schema(description = "알람 id")
     private Integer id;
 

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/response/AlarmSimpleRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/response/AlarmSimpleRes.java
@@ -17,7 +17,7 @@ public class AlarmSimpleRes {
     @Schema(description = "아이콘", example = "⏰")
     private String icon;
 
-    @Schema(name = "alarm_time", example = "06:00:00")
+    @Schema(name = "알람 시간", example = "06:00:00")
     private LocalTime alarmTime;
 
     @Schema(description = "알람 이름", example = "기상 알람")

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/model/Alarm.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/model/Alarm.java
@@ -42,8 +42,6 @@ public class Alarm {
 
     private String name;
 
-    private String icon;
-
     @Column(columnDefinition = "TIME")
     private LocalTime alarmTime;
 
@@ -78,11 +76,10 @@ public class Alarm {
     private Room room;
 
     @Builder
-    private Alarm(String name, String icon, LocalTime alarmTime, Boolean monday, Boolean tuesday,
+    private Alarm(String name, LocalTime alarmTime, Boolean monday, Boolean tuesday,
             Boolean wednesday, Boolean thursday, Boolean friday, Boolean saturday, Boolean sunday,
             Boolean isVibrate, User user, Mission mission, MissionObject missionObject) {
         this.name = name;
-        this.icon = icon;
         this.alarmTime = alarmTime;
         this.monday = monday;
         this.tuesday = tuesday;
@@ -97,13 +94,12 @@ public class Alarm {
         this.missionObject = missionObject;
     }
 
-    public static Alarm create(String name, String icon, LocalTime alarmTime, Boolean monday,
+    public static Alarm create(String name, LocalTime alarmTime, Boolean monday,
             Boolean tuesday, Boolean wednesday, Boolean thursday, Boolean friday, Boolean saturday,
             Boolean sunday, Boolean isVibrate, User user, Mission mission,
             MissionObject missionObject) {
         return Alarm.builder()
                 .name(name)
-                .icon(icon)
                 .alarmTime(alarmTime)
                 .monday(monday)
                 .tuesday(tuesday)
@@ -119,12 +115,11 @@ public class Alarm {
                 .build();
     }
 
-    public void modifyProperties(String name, String icon, LocalTime alarmTime, Boolean monday,
+    public void modifyProperties(String name, LocalTime alarmTime, Boolean monday,
             Boolean tuesday, Boolean wednesday, Boolean thursday, Boolean friday, Boolean saturday,
             Boolean sunday, Boolean isVibrate, Boolean isActivated, Mission mission,
             MissionObject missionObject) {
         this.name = name;
-        this.icon = icon;
         this.isVibrate = isVibrate;
         this.alarmTime = alarmTime;
         this.monday = monday;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
@@ -1,9 +1,7 @@
 package com.wakeUpTogetUp.togetUp.api.alarm.repository;
 
-import java.time.DayOfWeek;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
-import java.util.List;
+import static com.wakeUpTogetUp.togetUp.api.alarm.model.QAlarm.alarm;
+import static com.wakeUpTogetUp.togetUp.api.mission.model.QMissionObject.missionObject;
 
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
@@ -11,10 +9,10 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.QAlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.common.annotation.LogExecutionTime;
-
-import static com.wakeUpTogetUp.togetUp.api.alarm.model.QAlarm.alarm;
-import static com.wakeUpTogetUp.togetUp.api.mission.model.QMissionObject.missionObject;
-
+import java.time.DayOfWeek;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
@@ -29,7 +27,7 @@ public class AlarmQueryRepositoryImpl implements AlarmQueryRepository {
                 .select(
                         new QAlarmSimpleRes(
                                 alarm.id,
-                                alarm.icon,
+                                alarm.missionObject.icon,
                                 alarm.alarmTime,
                                 alarm.name,
                                 missionObject.kr,

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
@@ -4,7 +4,6 @@ import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.mission.model.MissionObject;
 import com.wakeUpTogetUp.togetUp.common.annotation.LogExecutionTime;
-
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -28,12 +27,19 @@ public interface AlarmRepository extends JpaRepository<Alarm, Integer>, AlarmQue
 
     @Query("SELECT a "
             + "FROM Alarm a "
-            + "WHERE a.room.id IN (SELECT ru.room.id FROM RoomUser ru WHERE ru.user.id = :userId) "
+            + "WHERE a.user.id = :userId "
+            + "AND a.room.id != null "
             + "ORDER BY a.alarmTime")
     List<Alarm> findRoomAlarmByUserId(@Param("userId") Integer userId);
 
     @LogExecutionTime
-    @Query("SELECT new com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes(a.id, a.icon, a.alarmTime, a.name, mo.kr, a.room.id) "
+    @Query("SELECT new com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes("
+            + "a.id, "
+            + "a.missionObject.icon, "
+            + "a.alarmTime, "
+            + "a.name, "
+            + "mo.kr, "
+            + "a.room.id) "
             + "FROM Alarm a "
             + "JOIN MissionObject mo ON mo.id = a.missionObject.id "
             + "JOIN MissionLog ml ON a.id = ml.alarm.id "

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
@@ -3,9 +3,9 @@ package com.wakeUpTogetUp.togetUp.api.alarm.service;
 import static com.wakeUpTogetUp.togetUp.common.Constant.GET_ALARM_MODE_GROUP;
 import static com.wakeUpTogetUp.togetUp.common.Constant.GET_ALARM_MODE_PERSONAL;
 
+import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmDetailRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmTimeLineRes;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.GetAlarmRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.alarm.repository.AlarmRepository;
 import com.wakeUpTogetUp.togetUp.api.users.UserValidationService;
@@ -13,15 +13,12 @@ import com.wakeUpTogetUp.togetUp.common.Status;
 import com.wakeUpTogetUp.togetUp.common.annotation.LogExecutionTime;
 import com.wakeUpTogetUp.togetUp.exception.BaseException;
 import com.wakeUpTogetUp.togetUp.utils.mapper.EntityDtoMapper;
-
 import java.time.LocalDateTime;
 import java.time.LocalTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-
 import lombok.RequiredArgsConstructor;
-
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,7 +30,7 @@ public class AlarmQueryService {
     private final UserValidationService userValidationService;
     private final AlarmRepository alarmRepository;
 
-    public List<GetAlarmRes> getAlarmsByUserIdOrderByDate(Integer userId, String type) {
+    public List<AlarmDetailRes> getAlarmsByUserIdOrderByDate(Integer userId, String type) {
         userValidationService.validateUserExist(userId);
 
         List<Alarm> alarms;
@@ -45,14 +42,14 @@ public class AlarmQueryService {
             throw new BaseException(Status.BAD_REQUEST_PARAM);
         }
 
-        return EntityDtoMapper.INSTANCE.toAlarmResList(alarms);
+        return EntityDtoMapper.INSTANCE.toAlarmDetailResList(alarms);
     }
 
-    public GetAlarmRes getAlarmById(Integer alarmId) {
+    public AlarmDetailRes getAlarmById(Integer alarmId) {
         Alarm alarm = alarmRepository.findById(alarmId)
                 .orElseThrow(() -> new BaseException(Status.ALARM_NOT_FOUND));
 
-        return EntityDtoMapper.INSTANCE.toAlarmRes(alarm);
+        return EntityDtoMapper.INSTANCE.toAlarmDetailRes(alarm);
     }
 
     @LogExecutionTime
@@ -60,7 +57,8 @@ public class AlarmQueryService {
         LocalTime time = now.toLocalTime();
 
         List<AlarmSimpleRes> timeline = getMergedTimeLine(userId, now);
-        AlarmSimpleRes nextAlarmRes = getNextAlarmSimpleRes(timeline, time).orElse(null);
+        AlarmSimpleRes nextAlarmRes = getNextAlarmSimpleRes(timeline, time)
+                .orElse(null);
 
         return AlarmTimeLineRes.builder()
                 .today(now.toLocalDate())

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmService.java
@@ -32,9 +32,8 @@ public class AlarmService {
     private final MissionRepository missionRepository;
     private final MissionObjectRepository missionObjectRepository;
 
-    @Deprecated
     @Transactional
-    public Alarm createAlarmDeprecated(Integer userId, PostAlarmReq postAlarmReq) {
+    public Alarm create(Integer userId, PostAlarmReq postAlarmReq) {
         User user = findExistingUser(userRepository, userId);
 
         Mission mission = null;
@@ -56,7 +55,6 @@ public class AlarmService {
 
         Alarm alarm = Alarm.create(
                 postAlarmReq.getName(),
-                postAlarmReq.getIcon(),
                 LocalTime.parse(postAlarmReq.getAlarmTime()),
                 postAlarmReq.getMonday(),
                 postAlarmReq.getTuesday(),
@@ -73,7 +71,6 @@ public class AlarmService {
 
     @Transactional
     public Alarm updateAlarm(Integer userId, Integer alarmId, PatchAlarmReq patchAlarmReq) {
-        // 알람 수정
         Alarm alarm = alarmRepository.findByIdAndUser_Id(alarmId, userId)
                 .orElseThrow(() -> new BaseException(Status.ALARM_NOT_FOUND));
         Mission mission = null;
@@ -95,7 +92,6 @@ public class AlarmService {
 
         alarm.modifyProperties(
                 patchAlarmReq.getName(),
-                patchAlarmReq.getIcon(),
                 LocalTime.parse(patchAlarmReq.getAlarmTime()),
                 patchAlarmReq.getMonday(),
                 patchAlarmReq.getTuesday(),

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomService.java
@@ -2,11 +2,11 @@ package com.wakeUpTogetUp.togetUp.api.room;
 
 import static com.wakeUpTogetUp.togetUp.api.users.UserServiceHelper.findExistingUser;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.repository.AlarmRepository;
-import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmService;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.AlarmCreateReq;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PostAlarmReq;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
+import com.wakeUpTogetUp.togetUp.api.alarm.repository.AlarmRepository;
+import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmService;
 import com.wakeUpTogetUp.togetUp.api.room.dto.request.RoomReq;
 import com.wakeUpTogetUp.togetUp.api.room.model.Room;
 import com.wakeUpTogetUp.togetUp.api.room.model.RoomUser;
@@ -40,7 +40,7 @@ public class RoomService {
 
         PostAlarmReq postAlarmReq = alarmMigrationMapper.convertAlarmCreateReqToPostAlarmReq(roomReq.getAlarmCreateReq());
 
-        Integer alarmId = alarmService.createAlarmDeprecated(userId, postAlarmReq).getId();
+        Integer alarmId = alarmService.create(userId, postAlarmReq).getId();
         Room savedRoom = roomRepository.save(room);
         this.joinRoom(savedRoom.getId(), userId);
 
@@ -84,7 +84,7 @@ public class RoomService {
     @Transactional
     public void createAlarmAndJoinRoom(Integer roomId, Integer invitedUserId, AlarmCreateReq alarmCreateReq) {
         PostAlarmReq postAlarmReq = alarmMigrationMapper.convertAlarmCreateReqToPostAlarmReq(alarmCreateReq);
-        Alarm alarm = alarmService.createAlarmDeprecated(invitedUserId, postAlarmReq);
+        Alarm alarm = alarmService.create(invitedUserId, postAlarmReq);
         alarmRepository.updateRoomIdByAlarmId(alarm.getId(), roomId);
         joinRoom(roomId, invitedUserId);
     }

--- a/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/AlarmMigrationMapper.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/AlarmMigrationMapper.java
@@ -9,7 +9,6 @@ public class AlarmMigrationMapper {
     public PostAlarmReq convertAlarmCreateReqToPostAlarmReq(AlarmCreateReq alarmCreateReq){
         return PostAlarmReq.of(
                 alarmCreateReq.getName(),
-                "⏰",
                 alarmCreateReq.getAlarmTime(),
                 alarmCreateReq.isMonday(),
                 alarmCreateReq.isTuesday(),

--- a/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
@@ -1,7 +1,7 @@
 package com.wakeUpTogetUp.togetUp.utils.mapper;
 
+import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmDetailRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.GetAlarmRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.avatar.domain.Avatar;
 import com.wakeUpTogetUp.togetUp.api.avatar.domain.UserAvatar;
@@ -28,20 +28,19 @@ public interface EntityDtoMapper {
 
     // Alarm
     @Mapping(target = "userId", source = "user.id")
+    @Mapping(target = "icon", source = "missionObject.icon")
     @Mapping(target = "getMissionRes", source = "mission")
     @Mapping(target = "getMissionObjectRes", source = "missionObject")
-    @Mapping(target = "roomRes", source = "room")
-    @Mapping(target = "roomRes.roomId", source = "room.id")
-    @Mapping(target = "roomRes.icon", source = "icon")
-    GetAlarmRes toAlarmRes(Alarm alarm);
+    @Mapping(target = "roomRes.roomId", source = "alarm.room.id")
+    @Mapping(target = "roomRes.name", source = "alarm.room.name")
+    AlarmDetailRes toAlarmDetailRes(Alarm alarm);
 
-    List<GetAlarmRes> toAlarmResList(List<Alarm> alarmList);
+    List<AlarmDetailRes> toAlarmDetailResList(List<Alarm> alarms);
 
+    @Mapping(target = "icon", source = "missionObject.icon")
     @Mapping(target = "alarmType", expression = "java(alarm.getAlarmType())")
     @Mapping(target = "missionObject", source = "alarm.missionObject.kr")
     AlarmSimpleRes toAlarmSimpleRes(Alarm alarm);
-
-    List<AlarmSimpleRes> toAlarmSimpleResList(List<Alarm> alarmList);
 
     // Mission
     GetMissionObjectRes toGetMissionObjectRes(MissionObject missionObject);

--- a/src/main/resources/migration/updates/20240813[alarm].sql
+++ b/src/main/resources/migration/updates/20240813[alarm].sql
@@ -1,0 +1,1 @@
+alter table alarm drop column icon;


### PR DESCRIPTION
## ☀️ 작업 사항

기획 정책 변경으로 알람의 icon을 사용자 정의하지 않고, 기존의 mission 데이터의 icon으로 대체하도록 구현했습니다.

## ☀️ 참고 사항

[변경된 API]
- 알람 상세 조회 API
- 알람 목록 조회 API
- 알람 타임라인 API
- 알람 생성 API
- 알람 수정 API