### PR TITLE
[FIX] 타임라인 목록 중복 제거

### DIFF
--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/AlarmQueryController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/AlarmQueryController.java
@@ -74,7 +74,7 @@ public class AlarmQueryController {
     })
     BaseResponse<AlarmTimeLineRes> getAlarmTimeLineOfUser(
             @Parameter(hidden = true) @AuthUser Integer userId,
-            @Parameter(description = "현지 타임존") @RequestParam String timezone
+            @Parameter(description = "현지 타임존", example = "Asia/Seoul") @RequestParam String timezone
     ) {
         LocalDateTime now = DateTimeProvider.getCurrentDateTime(timezone);
         AlarmTimeLineRes response = alarmQueryService.getTimeLine(userId, now);

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/response/AlarmSimpleRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/dto/response/AlarmSimpleRes.java
@@ -3,6 +3,7 @@ package com.wakeUpTogetUp.togetUp.api.alarm.dto.response;
 import com.querydsl.core.annotations.QueryProjection;
 import com.wakeUpTogetUp.togetUp.api.alarm.domain.AlarmType;
 import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
 import java.time.LocalTime;
 import lombok.Getter;
 import lombok.Setter;
@@ -26,7 +27,7 @@ public class AlarmSimpleRes {
     @Schema(description = "미션 객체", example = "시계")
     private String missionObject;
 
-    @Schema(description = "알람 종류 (`개인`, `그룹`)")
+    @Schema(description = "알람 종류")
     private AlarmType alarmType;
 
     @QueryProjection
@@ -34,6 +35,16 @@ public class AlarmSimpleRes {
         this.id = id;
         this.icon = icon;
         this.alarmTime = alarmTime;
+        this.name = name;
+        this.missionObject = missionObject;
+        this.alarmType = roomId != null ? AlarmType.GROUP : AlarmType.PERSONAL;
+    }
+
+    @QueryProjection
+    public AlarmSimpleRes(Integer id, String icon, LocalDateTime performedTime, String name, String missionObject, Integer roomId) {
+        this.id = id;
+        this.icon = icon;
+        this.alarmTime = LocalTime.of(performedTime.getHour(), performedTime.getMinute(), 0);
         this.name = name;
         this.missionObject = missionObject;
         this.alarmType = roomId != null ? AlarmType.GROUP : AlarmType.PERSONAL;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
@@ -36,7 +36,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Integer>, AlarmQue
     @Query("SELECT new com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes("
             + "a.id, "
             + "a.missionObject.icon, "
-            + "a.alarmTime, "
+            + "ml.createdAt, "
             + "a.name, "
             + "mo.kr, "
             + "a.room.id) "

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomController.java
@@ -28,7 +28,6 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
 @Tag(name = "Room", description = "그룹")
@@ -37,138 +36,135 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/app/room")
 public class RoomController {
 
-  private final RoomService roomService;
-  private final RoomQueryService roomQueryService;
-  private final RoomQueryRepository roomQueryRepository;
+    private final RoomService roomService;
+    private final RoomQueryService roomQueryService;
+    private final RoomQueryRepository roomQueryRepository;
 
-  @Operation(summary = "그룹과 그룹 알람 생성")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "201", description = "생성 되었습니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 입니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 방 입니다."),
-      @ApiResponse(responseCode = "409", description = "이미 방에 들어간 멤버입니다.")
-  })
-  @ResponseBody
-  @PostMapping()
-  public BaseResponse<RoomJoinRes> create(@Parameter(hidden = true) @AuthUser Integer userId,
-      @RequestBody RoomReq roomReq) {
+    @Operation(summary = "그룹과 그룹 알람 생성")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "201", description = "생성 되었습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 방 입니다."),
+            @ApiResponse(responseCode = "409", description = "이미 방에 들어간 멤버입니다.")
+    })
+    @PostMapping()
+    public BaseResponse<RoomJoinRes> create(@Parameter(hidden = true) @AuthUser Integer userId,
+            @RequestBody RoomReq roomReq) {
 
-    return new BaseResponse<>(Status.SUCCESS_CREATED, roomService.createRoom(userId, roomReq));
+        return new BaseResponse<>(Status.SUCCESS_CREATED, roomService.createRoom(userId, roomReq));
 
-  }
+    }
 
-  @Operation(summary = "그룹 알람 생성 및 그룹 참가")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 입니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 방 입니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 미션 입니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 미션 객체 입니다."),
-      @ApiResponse(responseCode = "409", description = "이미 방에 들어간 멤버입니다.")
-  })
-  @ResponseBody
-  @PostMapping("/join/{roomId}")
-  public BaseResponse<RoomJoinRes> join(@Parameter(hidden = true) @AuthUser Integer userId,
-      @Parameter(description = "룸 아이디", example = "1") @PathVariable Integer roomId,
-      @RequestBody AlarmCreateReq alarmCreateReq) {
+    @Operation(summary = "그룹 알람 생성 및 그룹 참가")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 방 입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 미션 입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 미션 객체 입니다."),
+            @ApiResponse(responseCode = "409", description = "이미 방에 들어간 멤버입니다.")
+    })
+    @PostMapping("/join/{roomId}")
+    public BaseResponse<RoomJoinRes> join(@Parameter(hidden = true) @AuthUser Integer userId,
+            @Parameter(description = "룸 아이디", example = "1") @PathVariable Integer roomId,
+            @RequestBody AlarmCreateReq alarmCreateReq) {
 
-    return new BaseResponse<>(Status.SUCCESS,
-        roomService.createAlarmAndJoinRoom(roomId, userId, alarmCreateReq));
+        return new BaseResponse<>(Status.SUCCESS,
+                roomService.createAlarmAndJoinRoom(roomId, userId, alarmCreateReq));
 
-  }
+    }
 
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
-          content = @Content(schema = @Schema(implementation = RoomRes.class))
-      )})
-  @Operation(summary = "그룹 리스트 불러오기")
-  @GetMapping()
-  public BaseResponse<List<RoomRes>> getList(@Parameter(hidden = true) @AuthUser Integer userId) {
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
+                    content = @Content(schema = @Schema(implementation = RoomRes.class))
+            )})
+    @Operation(summary = "그룹 리스트 불러오기")
+    @GetMapping()
+    public BaseResponse<List<RoomRes>> getList(@Parameter(hidden = true) @AuthUser Integer userId) {
 
-    return new BaseResponse(Status.SUCCESS, roomQueryRepository.findRoomsOrderedByJoinTime(userId));
+        return new BaseResponse(Status.SUCCESS,
+                roomQueryRepository.findRoomsOrderedByJoinTime(userId));
 
-  }
+    }
 
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
-          content = @Content(schema = @Schema(implementation = RoomUserMissionLogRes.class))),
-      @ApiResponse(responseCode = "404", description = "그룹의 해당 멤버가 없습니다."),
-      @ApiResponse(responseCode = "500", description = "유저의 대표 아바타 정보를 가져오는데 실패했습니다."),
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
+                    content = @Content(schema = @Schema(implementation = RoomUserMissionLogRes.class))),
+            @ApiResponse(responseCode = "404", description = "그룹의 해당 멤버가 없습니다."),
+            @ApiResponse(responseCode = "500", description = "유저의 대표 아바타 정보를 가져오는데 실패했습니다."),
 
-  })
-  @Operation(summary = "그룹게시판의 미션기록 불러오기", description = "그룹의 멤버의 미션기록 보기")
-  @GetMapping("/user/mission-log")
-  public BaseResponse<RoomUserMissionLogRes> getRoomLogDetailByDate(
-      @Parameter(hidden = true) @AuthUser Integer userId,
-      @Parameter(description = "룸 아이디", example = "1") @RequestParam Integer roomId,
-      @Parameter(description = "기록을 가져올 날의 LocalDate 값", example = "2023-09-20")
-      @RequestParam("localDate")
-      @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate
-  ) {
+    })
+    @Operation(summary = "그룹게시판의 미션기록 불러오기", description = "그룹의 멤버의 미션기록 보기")
+    @GetMapping("/user/mission-log")
+    public BaseResponse<RoomUserMissionLogRes> getRoomLogDetailByDate(
+            @Parameter(hidden = true) @AuthUser Integer userId,
+            @Parameter(description = "룸 아이디", example = "1") @RequestParam Integer roomId,
+            @Parameter(description = "기록을 가져올 날의 LocalDate 값", example = "2023-09-20")
+            @RequestParam("localDate")
+            @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate localDate
+    ) {
 
-    return new BaseResponse(Status.SUCCESS,
-        roomQueryService.getRoomUserLogList(userId, roomId, localDate));
+        return new BaseResponse(Status.SUCCESS,
+                roomQueryService.getRoomUserLogList(userId, roomId, localDate));
 
-  }
+    }
 
-  @Operation(summary = "그룹 나가기")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
-      @ApiResponse(responseCode = "404", description = "그룹의 멤버가 없습니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 알람입니다.")
-  })
-  @DeleteMapping("{roomId}/member")
-  public BaseResponse leaveRoom(@Parameter(hidden = true) @AuthUser Integer userId,
-      @PathVariable Integer roomId) {
+    @Operation(summary = "그룹 나가기")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
+            @ApiResponse(responseCode = "404", description = "그룹의 멤버가 없습니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 알람입니다.")
+    })
+    @DeleteMapping("{roomId}/member")
+    public BaseResponse leaveRoom(@Parameter(hidden = true) @AuthUser Integer userId,
+            @PathVariable Integer roomId) {
 
-    roomService.leaveRoom(roomId, userId);
-    return new BaseResponse(Status.SUCCESS);
+        roomService.leaveRoom(roomId, userId);
+        return new BaseResponse(Status.SUCCESS);
 
-  }
-
-
-  @Operation(summary = "그룹 디테일 보기 ", description = "그룹 디테일 보기 (설정 화면)")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
-          content = @Content(schema = @Schema(implementation = RoomDetailRes.class))),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 알람입니다.")})
-  @GetMapping("/{roomId}")
-  public BaseResponse<RoomDetailRes> getRoomDetail(
-      @Parameter(hidden = true) @AuthUser Integer userId, @PathVariable Integer roomId) {
-
-    return new BaseResponse(Status.SUCCESS, roomQueryService.getRoomDetail(roomId, userId));
-
-  }
-
-  @Operation(summary = "그룹 푸쉬 알림 설정")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
-      @ApiResponse(responseCode = "404", description = "그룹의 해당 멤버가 없습니다."),})
-  @ResponseBody
-  @PostMapping("/user/push/{roomId}")
-  public BaseResponse updateAgreePush(@Parameter(hidden = true) @AuthUser Integer userId,
-      @PathVariable Integer roomId,
-      @Parameter(description = "알람동의 값", example = "true") @RequestParam() boolean agreePush) {
-
-    roomService.updateAgreePush(roomId, userId, agreePush);
-    return new BaseResponse(Status.SUCCESS);
-
-  }
+    }
 
 
-  @Operation(summary = "초대 받은 사람에게 보이는 그룹 정보 보기 ", description = "초대 받은 사람에게 보이는 앱 내 페이지")
-  @ApiResponses(value = {
-      @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
-          content = @Content(schema = @Schema(implementation = RoomInviteInfoRes.class))),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 알람 입니다."),
-      @ApiResponse(responseCode = "404", description = "존재하지 않는 룸입니다.")
-  })
-  @GetMapping("/information")
-  public BaseResponse<RoomInviteInfoRes> getRoomIntro(@RequestParam() String invitationCode) {
+    @Operation(summary = "그룹 디테일 보기 ", description = "그룹 디테일 보기 (설정 화면)")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
+                    content = @Content(schema = @Schema(implementation = RoomDetailRes.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 알람입니다.")})
+    @GetMapping("/{roomId}")
+    public BaseResponse<RoomDetailRes> getRoomDetail(
+            @Parameter(hidden = true) @AuthUser Integer userId, @PathVariable Integer roomId) {
 
-    return new BaseResponse(Status.SUCCESS, roomQueryService.getRoomInformation(invitationCode));
+        return new BaseResponse(Status.SUCCESS, roomQueryService.getRoomDetail(roomId, userId));
 
-  }
+    }
+
+    @Operation(summary = "그룹 푸쉬 알림 설정")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다."),
+            @ApiResponse(responseCode = "404", description = "그룹의 해당 멤버가 없습니다."),})
+    @PostMapping("/user/push/{roomId}")
+    public BaseResponse updateAgreePush(@Parameter(hidden = true) @AuthUser Integer userId,
+            @PathVariable Integer roomId,
+            @Parameter(description = "알람동의 값", example = "true") @RequestParam() boolean agreePush) {
+
+        roomService.updateAgreePush(roomId, userId, agreePush);
+        return new BaseResponse(Status.SUCCESS);
+
+    }
 
 
+    @Operation(summary = "초대 받은 사람에게 보이는 그룹 정보 보기 ", description = "초대 받은 사람에게 보이는 앱 내 페이지")
+    @ApiResponses(value = {
+            @ApiResponse(responseCode = "200", description = "요청에 성공하였습니다.",
+                    content = @Content(schema = @Schema(implementation = RoomInviteInfoRes.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 알람 입니다."),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 룸입니다.")
+    })
+    @GetMapping("/information")
+    public BaseResponse<RoomInviteInfoRes> getRoomIntro(@RequestParam() String invitationCode) {
+
+        return new BaseResponse(Status.SUCCESS,
+                roomQueryService.getRoomInformation(invitationCode));
+
+    }
 }

--- a/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
@@ -1,7 +1,6 @@
 package com.wakeUpTogetUp.togetUp.utils.mapper;
 
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmDetailRes;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.avatar.domain.Avatar;
 import com.wakeUpTogetUp.togetUp.api.avatar.domain.UserAvatar;
@@ -37,11 +36,6 @@ public interface EntityDtoMapper {
 
     List<AlarmDetailRes> toAlarmDetailResList(List<Alarm> alarms);
 
-    @Mapping(target = "icon", source = "missionObject.icon")
-    @Mapping(target = "alarmType", expression = "java(alarm.getAlarmType())")
-    @Mapping(target = "missionObject", source = "alarm.missionObject.kr")
-    AlarmSimpleRes toAlarmSimpleRes(Alarm alarm);
-
     // Mission
     GetMissionObjectRes toGetMissionObjectRes(MissionObject missionObject);
 
@@ -49,8 +43,6 @@ public interface EntityDtoMapper {
 
     @Mapping(target = "missionObjectResList", source = "mission.missionObjectList")
     GetMissionWithObjectListRes toGetMissionRes(Mission mission);
-
-    List<GetMissionWithObjectListRes> toGetMissionResList(List<Mission> missionList);
 
 
     // GetMissionLogRes


### PR DESCRIPTION
## ☀️ 작업 사항
- 알람 타임라인 목록에서 기록이 있는 지난 알람과 시간을 변경한 수행한 알람이 두 번 조회되어 알람이 중복되는 버그가 있었습니다.
- 기능 자체에 문제는 없지만, 알람 시간을 수정하면 이전에 수행한 알람도 현재 시간으로 변경되기 때문에 같은 알람 항목이 여러 개가 되었습니다.
- 따라서 이전에 타임라인 기능에 대해 논의한대로 현재시간 이전의 알람은 수행한 알람만, 이후의 알람은 현재 시간 이후의 알람을 가져오는 방식의 의미를 살리기 위해서 사소한 변경을 했습니다.
- 현재시간 이전의 알람의 경우 타임라인에 표시할 때 알람 시간을 미션을 수행한 시간으로 반영하도록 구현했습니다.

## ☀️ 참고 사항
- 이전 (수행한 알람이든 이후 알람이든 알람 시간으로 표현)
<img src="https://github.com/user-attachments/assets/6c6cadd7-edb5-40df-8fbc-96f1ca3f944b" width="200">

- 이후 (수행한 알람은 수행된 시간으로 알람 시간을 표현)
<img src="https://github.com/user-attachments/assets/9420dfe0-4efc-453a-88a7-12f7ab95def1" width="200">

- +) RoomContoller에 적용되지 않는 위치에 `@ResponseBody`가 몇군데 있던데 혹시 무슨 의미일까요? 우선은 삭제했는데 코멘트 주시면 좋을 것 같습니다.