### PR TITLE
#133 [REFACTOR] 알람 조회 DTO 불필요한 필드 삭제 및 네이밍 리팩터링

### DIFF
--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/AlarmController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/AlarmController.java
@@ -1,8 +1,8 @@
-package com.wakeUpTogetUp.togetUp.api.alarm;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.AlarmsDeactivateReq;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PatchAlarmReq;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PostAlarmReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.AlarmsDeactivateReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.PatchAlarmReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.PostAlarmReq;
 import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmService;
 import com.wakeUpTogetUp.togetUp.api.auth.AuthUser;
 import com.wakeUpTogetUp.togetUp.common.Status;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/AlarmQueryController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/AlarmQueryController.java
@@ -1,7 +1,7 @@
-package com.wakeUpTogetUp.togetUp.api.alarm;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmDetailRes;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmTimeLineRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmDetailRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmTimeLineRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmQueryService;
 import com.wakeUpTogetUp.togetUp.api.auth.AuthUser;
 import com.wakeUpTogetUp.togetUp.common.Status;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/AlarmQueryController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/AlarmQueryController.java
@@ -56,11 +56,12 @@ public class AlarmQueryController {
     })
     @GetMapping
     public BaseResponse<List<AlarmDetailRes>> getAlarmsByUserId(
-            @Parameter(description = "- 개인 : personal\n- 그룹 : group", example = "personal") String type,
+            @Parameter(description = "PERSONAL/GROUP", example = "PERSONAL") String type,
             @Parameter(hidden = true) @AuthUser Integer userId
     ) {
-        return new BaseResponse<>(Status.SUCCESS,
-                alarmQueryService.getAlarmsByUserIdOrderByDate(userId, type));
+        List<AlarmDetailRes> response = alarmQueryService.getAlarmsByUserIdOrderByDate(userId, type);
+
+        return new BaseResponse<>(Status.SUCCESS, response);
     }
 
     @LogExecutionTime

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/AlarmCreateReq.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/AlarmCreateReq.java
@@ -1,21 +1,20 @@
-package com.wakeUpTogetUp.togetUp.api.alarm.dto.request;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import lombok.Setter;
 
 @Schema(description = "알람 생성 request")
 @Getter
-@Setter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(staticName = "of")
-public class PostAlarmReq {
+public class AlarmCreateReq {
     @Schema(description = "알람 이름", requiredMode = RequiredMode.REQUIRED, example = "기상")
     @NotBlank(message = "알람 이름은 공백일 수 없습니다.")
     private String name;
@@ -26,27 +25,27 @@ public class PostAlarmReq {
     private String alarmTime;
 
     @Schema(description = "월요일 울림 여부", defaultValue = "false", example = "false")
-    private Boolean monday;
+    private boolean monday;
 
     @Schema(description = "화요일 울림 여부", defaultValue = "false", example = "false")
-    private Boolean tuesday;
+    private boolean tuesday;
 
     @Schema(description = "수요일 울림 여부", defaultValue = "false", example = "false")
-    private Boolean wednesday;
+    private boolean wednesday;
 
     @Schema(description = "목요일 울림 여부", defaultValue = "false", example = "false")
-    private Boolean thursday;
+    private boolean thursday;
 
     @Schema(description = "금요일 울림 여부", defaultValue = "false", example = "false")
-    private Boolean friday;
+    private boolean friday;
 
     @Schema(description = "토요일 울림 여부", defaultValue = "false", example = "false")
-    private Boolean saturday;
+    private boolean saturday;
 
     @Schema(description = "일요일 울림 여부", defaultValue = "false", example = "false")
-    private Boolean sunday;
+    private boolean sunday;
 
-    @Schema(description = "진동 활성화 여부", defaultValue = "true", example = "true")
+    @Schema(description = "진동 활성화 여부", defaultValue = "true", example = "true",name = "isVibrate")
     private Boolean isVibrate;
 
     @Schema(description = "미션 id", requiredMode = RequiredMode.REQUIRED, example = "2")

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/AlarmsDeactivateReq.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/AlarmsDeactivateReq.java
@@ -1,4 +1,4 @@
-package com.wakeUpTogetUp.togetUp.api.alarm.dto.request;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request;
 
 import java.util.List;
 import lombok.Getter;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/PatchAlarmReq.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/PatchAlarmReq.java
@@ -1,4 +1,4 @@
-package com.wakeUpTogetUp.togetUp.api.alarm.dto.request;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotNull;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/PostAlarmReq.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/request/PostAlarmReq.java
@@ -1,20 +1,21 @@
-package com.wakeUpTogetUp.togetUp.api.alarm.dto.request;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.media.Schema.RequiredMode;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
-import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.Setter;
 
 @Schema(description = "알람 생성 request")
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Setter
+@NoArgsConstructor
 @AllArgsConstructor(staticName = "of")
-public class AlarmCreateReq {
+public class PostAlarmReq {
     @Schema(description = "알람 이름", requiredMode = RequiredMode.REQUIRED, example = "기상")
     @NotBlank(message = "알람 이름은 공백일 수 없습니다.")
     private String name;
@@ -25,27 +26,27 @@ public class AlarmCreateReq {
     private String alarmTime;
 
     @Schema(description = "월요일 울림 여부", defaultValue = "false", example = "false")
-    private boolean monday;
+    private Boolean monday;
 
     @Schema(description = "화요일 울림 여부", defaultValue = "false", example = "false")
-    private boolean tuesday;
+    private Boolean tuesday;
 
     @Schema(description = "수요일 울림 여부", defaultValue = "false", example = "false")
-    private boolean wednesday;
+    private Boolean wednesday;
 
     @Schema(description = "목요일 울림 여부", defaultValue = "false", example = "false")
-    private boolean thursday;
+    private Boolean thursday;
 
     @Schema(description = "금요일 울림 여부", defaultValue = "false", example = "false")
-    private boolean friday;
+    private Boolean friday;
 
     @Schema(description = "토요일 울림 여부", defaultValue = "false", example = "false")
-    private boolean saturday;
+    private Boolean saturday;
 
     @Schema(description = "일요일 울림 여부", defaultValue = "false", example = "false")
-    private boolean sunday;
+    private Boolean sunday;
 
-    @Schema(description = "진동 활성화 여부", defaultValue = "true", example = "true",name = "isVibrate")
+    @Schema(description = "진동 활성화 여부", defaultValue = "true", example = "true")
     private Boolean isVibrate;
 
     @Schema(description = "미션 id", requiredMode = RequiredMode.REQUIRED, example = "2")

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmDetailRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmDetailRes.java
@@ -1,8 +1,7 @@
 package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response;
 
-import com.wakeUpTogetUp.togetUp.api.mission.dto.response.GetMissionObjectRes;
-import com.wakeUpTogetUp.togetUp.api.mission.dto.response.GetMissionRes;
-import com.wakeUpTogetUp.togetUp.api.room.dto.response.RoomRes;
+import com.wakeUpTogetUp.togetUp.api.mission.dto.response.MissionObjectRes;
+import com.wakeUpTogetUp.togetUp.api.mission.dto.response.MissionRes;
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalTime;
 import lombok.AllArgsConstructor;
@@ -10,7 +9,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
-@Schema(description = "알람 상세 조회 response")
+@Schema(description = "알람 조회 응답")
 @Getter
 @Setter
 @NoArgsConstructor
@@ -24,9 +23,6 @@ public class AlarmDetailRes {
 
     @Schema(description = "알람 이름", example = "기상 알람")
     private String name;
-
-    @Schema(description = "아이콘", example = "⏰")
-    private String icon;
 
     @Schema(description = "알람 시간", example = "06:00:00")
     private LocalTime alarmTime;
@@ -59,13 +55,11 @@ public class AlarmDetailRes {
     private Boolean isActivated;
 
     @Schema(description = "미션")
-    private GetMissionRes getMissionRes;
+    private MissionRes missionRes;
 
     @Schema(description = "미션 객체")
-    private GetMissionObjectRes getMissionObjectRes;
+    private MissionObjectRes missionObjectRes;
 
     @Schema(description = "그룹 정보")
-    private RoomRes roomRes;
+    private AlarmRoomRes alarmRoomRes;
 }
-
-

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmDetailRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmDetailRes.java
@@ -1,4 +1,4 @@
-package com.wakeUpTogetUp.togetUp.api.alarm.dto.response;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response;
 
 import com.wakeUpTogetUp.togetUp.api.mission.dto.response.GetMissionObjectRes;
 import com.wakeUpTogetUp.togetUp.api.mission.dto.response.GetMissionRes;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmRoomRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmRoomRes.java
@@ -1,0 +1,12 @@
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public class AlarmRoomRes {
+
+    private Integer id;
+    private String name;
+}

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmSimpleRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmSimpleRes.java
@@ -1,4 +1,4 @@
-package com.wakeUpTogetUp.togetUp.api.alarm.dto.response;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response;
 
 import com.querydsl.core.annotations.QueryProjection;
 import com.wakeUpTogetUp.togetUp.api.alarm.domain.AlarmType;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmTimeLineRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/controller/dto/response/AlarmTimeLineRes.java
@@ -1,4 +1,4 @@
-package com.wakeUpTogetUp.togetUp.api.alarm.dto.response;
+package com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.DayOfWeek;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepository.java
@@ -1,9 +1,8 @@
 package com.wakeUpTogetUp.togetUp.api.alarm.repository;
 
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes;
 import java.time.LocalDateTime;
 import java.util.List;
-
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
 
 public interface AlarmQueryRepository {
 

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
@@ -6,7 +6,7 @@ import static com.wakeUpTogetUp.togetUp.api.mission.model.QMissionObject.mission
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.QAlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.common.annotation.LogExecutionTime;
 import java.time.DayOfWeek;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
@@ -7,7 +7,7 @@ import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.QAlarmSimpleRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.QAlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.common.annotation.LogExecutionTime;
 import java.time.DayOfWeek;
 import java.time.LocalDateTime;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
@@ -1,6 +1,6 @@
 package com.wakeUpTogetUp.togetUp.api.alarm.repository;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.mission.model.MissionObject;
 import com.wakeUpTogetUp.togetUp.common.annotation.LogExecutionTime;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
@@ -33,7 +33,7 @@ public interface AlarmRepository extends JpaRepository<Alarm, Integer>, AlarmQue
     List<Alarm> findRoomAlarmByUserId(@Param("userId") Integer userId);
 
     @LogExecutionTime
-    @Query("SELECT new com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes("
+    @Query("SELECT new com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes("
             + "a.id, "
             + "a.missionObject.icon, "
             + "ml.createdAt, "

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
@@ -3,9 +3,9 @@ package com.wakeUpTogetUp.togetUp.api.alarm.service;
 import static com.wakeUpTogetUp.togetUp.common.Constant.GET_ALARM_MODE_GROUP;
 import static com.wakeUpTogetUp.togetUp.common.Constant.GET_ALARM_MODE_PERSONAL;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmDetailRes;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmSimpleRes;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmTimeLineRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmDetailRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmTimeLineRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.alarm.repository.AlarmRepository;
 import com.wakeUpTogetUp.togetUp.api.users.UserValidationService;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
@@ -13,9 +13,10 @@ import com.wakeUpTogetUp.togetUp.exception.BaseException;
 import com.wakeUpTogetUp.togetUp.utils.mapper.EntityDtoMapper;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,13 +72,15 @@ public class AlarmQueryService {
 
     @LogExecutionTime
     private List<AlarmSimpleRes> getMergedTimeLine(Integer userId, LocalDateTime now) {
-        List<AlarmSimpleRes> alarmsWithTodayLog = alarmRepository.findAllUserAlarmsWithTodayLog(userId, now.toLocalDate().atStartOfDay());
-        List<AlarmSimpleRes> alarmsActiveAfterNow = alarmRepository.findAllUserTodayActiveAlarmsAfterNow(userId, now);
+        List<AlarmSimpleRes> alarmsWithTodayLog =
+                alarmRepository.findAllUserAlarmsWithTodayLog(userId, now.toLocalDate().atStartOfDay());
+        List<AlarmSimpleRes> alarmsActiveAfterNow =
+                alarmRepository.findAllUserTodayActiveAlarmsAfterNow(userId, now);
 
-        List<AlarmSimpleRes> timeline = new ArrayList<>(alarmsWithTodayLog);
-        timeline.addAll(alarmsActiveAfterNow);
-
-        return timeline;
+        return Stream.concat(
+                        alarmsWithTodayLog.stream(),
+                        alarmsActiveAfterNow.stream())
+                .collect(Collectors.toList());
     }
 
     private Optional<AlarmSimpleRes> getNextAlarmSimpleRes(List<AlarmSimpleRes> timeLine, LocalTime now) {

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmQueryService.java
@@ -1,11 +1,9 @@
 package com.wakeUpTogetUp.togetUp.api.alarm.service;
 
-import static com.wakeUpTogetUp.togetUp.common.Constant.GET_ALARM_MODE_GROUP;
-import static com.wakeUpTogetUp.togetUp.common.Constant.GET_ALARM_MODE_PERSONAL;
-
 import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmDetailRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmTimeLineRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.domain.AlarmType;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.alarm.repository.AlarmRepository;
 import com.wakeUpTogetUp.togetUp.api.users.UserValidationService;
@@ -30,26 +28,29 @@ public class AlarmQueryService {
     private final UserValidationService userValidationService;
     private final AlarmRepository alarmRepository;
 
-    public List<AlarmDetailRes> getAlarmsByUserIdOrderByDate(Integer userId, String type) {
-        userValidationService.validateUserExist(userId);
-
-        List<Alarm> alarms;
-        if (type.equals(GET_ALARM_MODE_PERSONAL)) {
-            alarms = alarmRepository.findAllByUser_IdAndRoom_IdIsNullOrderByAlarmTime(userId);
-        } else if (type.equals(GET_ALARM_MODE_GROUP)) {
-            alarms = alarmRepository.findRoomAlarmByUserId(userId);
-        } else {
-            throw new BaseException(Status.BAD_REQUEST_PARAM);
-        }
-
-        return EntityDtoMapper.INSTANCE.toAlarmDetailResList(alarms);
-    }
-
     public AlarmDetailRes getAlarmById(Integer alarmId) {
         Alarm alarm = alarmRepository.findById(alarmId)
                 .orElseThrow(() -> new BaseException(Status.ALARM_NOT_FOUND));
 
         return EntityDtoMapper.INSTANCE.toAlarmDetailRes(alarm);
+    }
+
+    public List<AlarmDetailRes> getAlarmsByUserIdOrderByDate(Integer userId, String type) {
+        userValidationService.validateUserExist(userId);
+
+        List<Alarm> alarms;
+        switch (AlarmType.valueOf(type)) {
+            case PERSONAL:
+                alarms = alarmRepository.findAllByUser_IdAndRoom_IdIsNullOrderByAlarmTime(userId);
+                break;
+            case GROUP:
+                alarms = alarmRepository.findRoomAlarmByUserId(userId);
+                break;
+            default:
+                throw new BaseException(Status.BAD_REQUEST_PARAM);
+        }
+
+        return EntityDtoMapper.INSTANCE.toAlarmDetailResList(alarms);
     }
 
     @LogExecutionTime

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/service/AlarmService.java
@@ -2,8 +2,8 @@ package com.wakeUpTogetUp.togetUp.api.alarm.service;
 
 import static com.wakeUpTogetUp.togetUp.api.users.UserServiceHelper.findExistingUser;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PatchAlarmReq;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PostAlarmReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.PatchAlarmReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.PostAlarmReq;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.alarm.repository.AlarmRepository;
 import com.wakeUpTogetUp.togetUp.api.mission.model.Mission;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/dto/response/GetMissionWithObjectListRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/dto/response/GetMissionWithObjectListRes.java
@@ -20,5 +20,5 @@ public class GetMissionWithObjectListRes {
     private String createdAt;
     private Boolean isActive;
     @Schema(description = "해당 미션이 인식 가능한 객체 목록")
-    private List<GetMissionObjectRes> missionObjectResList;
+    private List<MissionObjectRes> missionObjectResList;
 }

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/dto/response/MissionObjectRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/dto/response/MissionObjectRes.java
@@ -9,7 +9,7 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetMissionObjectRes {
+public class MissionObjectRes {
     private int id;
     private String name;
     private String kr;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/dto/response/MissionRes.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/mission/dto/response/MissionRes.java
@@ -11,7 +11,7 @@ import lombok.Setter;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class GetMissionRes {
+public class MissionRes {
     private int id;
     private String name;
     private String createdAt;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomController.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomController.java
@@ -1,6 +1,6 @@
 package com.wakeUpTogetUp.togetUp.api.room;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.AlarmCreateReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.AlarmCreateReq;
 import com.wakeUpTogetUp.togetUp.api.auth.AuthUser;
 import com.wakeUpTogetUp.togetUp.api.room.dto.request.RoomReq;
 import com.wakeUpTogetUp.togetUp.api.room.dto.response.RoomDetailRes;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomService.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/RoomService.java
@@ -2,8 +2,8 @@ package com.wakeUpTogetUp.togetUp.api.room;
 
 import static com.wakeUpTogetUp.togetUp.api.users.UserServiceHelper.findExistingUser;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.AlarmCreateReq;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PostAlarmReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.AlarmCreateReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.PostAlarmReq;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.alarm.repository.AlarmRepository;
 import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmService;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/room/dto/request/RoomReq.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/room/dto/request/RoomReq.java
@@ -1,7 +1,7 @@
 package com.wakeUpTogetUp.togetUp.api.room.dto.request;
 
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.AlarmCreateReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.AlarmCreateReq;
 import io.swagger.v3.oas.annotations.media.Schema;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/common/Constant.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/common/Constant.java
@@ -8,9 +8,6 @@ public class Constant {
 	public static final String JWT_PREFIX = "Bearer";
 	public static final Integer INVITATION_CODE_LENGTH = 5;
 	public static final String AUTHORIZATION_CODE = "authorization_code";
-	public static final String GET_ALARM_MODE_PERSONAL = "personal";
-	public static final String GET_ALARM_MODE_GROUP = "group";
-
 	public static final String ROOM_USER_MISSION_IMG_WAITING = "http://waiting~";
 	public static final String ROOM_USER_MISSION_IMG_FAIL = "http://fail~";
 	public static final String ROOM_USER_MISSION_IMG_NOT_MISSION = "http://not-mission~";

--- a/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/AlarmMigrationMapper.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/AlarmMigrationMapper.java
@@ -1,7 +1,7 @@
 package com.wakeUpTogetUp.togetUp.utils.mapper;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.AlarmCreateReq;
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.request.PostAlarmReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.AlarmCreateReq;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.request.PostAlarmReq;
 import org.springframework.stereotype.Component;
 @Component
 public class AlarmMigrationMapper {

--- a/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
@@ -1,6 +1,6 @@
 package com.wakeUpTogetUp.togetUp.utils.mapper;
 
-import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.AlarmDetailRes;
+import com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmDetailRes;
 import com.wakeUpTogetUp.togetUp.api.alarm.model.Alarm;
 import com.wakeUpTogetUp.togetUp.api.avatar.domain.Avatar;
 import com.wakeUpTogetUp.togetUp.api.avatar.domain.UserAvatar;

--- a/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
@@ -27,7 +27,6 @@ public interface EntityDtoMapper {
 
     // Alarm
     @Mapping(target = "userId", source = "user.id")
-    @Mapping(target = "icon", source = "missionObject.icon")
     @Mapping(target = "missionRes", source = "mission")
     @Mapping(target = "missionObjectRes", source = "missionObject")
     @Mapping(target = "alarmRoomRes.id", source = "alarm.room.id")

--- a/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/utils/mapper/EntityDtoMapper.java
@@ -7,8 +7,8 @@ import com.wakeUpTogetUp.togetUp.api.avatar.domain.UserAvatar;
 import com.wakeUpTogetUp.togetUp.api.avatar.dto.response.AvatarSpeechResponse;
 import com.wakeUpTogetUp.togetUp.api.avatar.dto.response.UserAvatarResponse;
 import com.wakeUpTogetUp.togetUp.api.mission.dto.response.GetMissionLogRes;
-import com.wakeUpTogetUp.togetUp.api.mission.dto.response.GetMissionObjectRes;
 import com.wakeUpTogetUp.togetUp.api.mission.dto.response.GetMissionWithObjectListRes;
+import com.wakeUpTogetUp.togetUp.api.mission.dto.response.MissionObjectRes;
 import com.wakeUpTogetUp.togetUp.api.mission.model.Mission;
 import com.wakeUpTogetUp.togetUp.api.mission.model.MissionLog;
 import com.wakeUpTogetUp.togetUp.api.mission.model.MissionObject;
@@ -28,18 +28,18 @@ public interface EntityDtoMapper {
     // Alarm
     @Mapping(target = "userId", source = "user.id")
     @Mapping(target = "icon", source = "missionObject.icon")
-    @Mapping(target = "getMissionRes", source = "mission")
-    @Mapping(target = "getMissionObjectRes", source = "missionObject")
-    @Mapping(target = "roomRes.roomId", source = "alarm.room.id")
-    @Mapping(target = "roomRes.name", source = "alarm.room.name")
+    @Mapping(target = "missionRes", source = "mission")
+    @Mapping(target = "missionObjectRes", source = "missionObject")
+    @Mapping(target = "alarmRoomRes.id", source = "alarm.room.id")
+    @Mapping(target = "alarmRoomRes.name", source = "alarm.room.name")
     AlarmDetailRes toAlarmDetailRes(Alarm alarm);
 
     List<AlarmDetailRes> toAlarmDetailResList(List<Alarm> alarms);
 
     // Mission
-    GetMissionObjectRes toGetMissionObjectRes(MissionObject missionObject);
+    MissionObjectRes toGetMissionObjectRes(MissionObject missionObject);
 
-    List<GetMissionObjectRes> toGetMissionObjectResList(List<MissionObject> missionObjectList);
+    List<MissionObjectRes> toGetMissionObjectResList(List<MissionObject> missionObjectList);
 
     @Mapping(target = "missionObjectResList", source = "mission.missionObjectList")
     GetMissionWithObjectListRes toGetMissionRes(Mission mission);

--- a/src/test/java/com/wakeUpTogetUp/togetUp/alarm/AlarmControllerTest.java
+++ b/src/test/java/com/wakeUpTogetUp/togetUp/alarm/AlarmControllerTest.java
@@ -1,7 +1,7 @@
 //package com.wakeUpTogetUp.togetUp.alarm;
 //
 //import com.fasterxml.jackson.databind.ObjectMapper;
-//import com.wakeUpTogetUp.togetUp.api.alarm.AlarmController;
+//import com.wakeUpTogetUp.togetUp.api.alarm.controller.AlarmController;
 //import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmProvider;
 //import com.wakeUpTogetUp.togetUp.api.alarm.service.AlarmService;
 //import com.wakeUpTogetUp.togetUp.api.alarm.dto.response.GetAlarmRes;


### PR DESCRIPTION
## ☀️ 작업 사항
> 알람 조회 DTO AlarmDetailRes에서 불필요한 필드들을 삭제하고 변수 네이밍을 가독성을 우선시하여 리팩터링 했습니다.

- 상수를 사용하던 알람 유형을 enum으로 교체
- dto에서 필요없는 필드 삭제

## ☀️ 관련 이슈
related : #133

## ☀️ 참고 사항
- 이번에 리팩터링하면서 개선된 switch 문이나 record 등을 사용하지 못해 조금 불편함을 느꼈습니다.
- stream의 경우도 높은 버전의 java에서 더 많은 기능이 있어 혹시 다음 리팩터링을 하면서  java 17 버전으로 마이그레이션하는 것에 대해 논의해보고 싶습니다!