### PR TITLE
[FIX] 브리핑 보드 알람 타임라인 정렬 에러 해결

### DIFF
--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmQueryRepositoryImpl.java
@@ -27,7 +27,7 @@ public class AlarmQueryRepositoryImpl implements AlarmQueryRepository {
                 .select(
                         new QAlarmSimpleRes(
                                 alarm.id,
-                                alarm.missionObject.icon,
+                                    missionObject.icon,
                                 alarm.alarmTime,
                                 alarm.name,
                                 missionObject.kr,
@@ -35,9 +35,12 @@ public class AlarmQueryRepositoryImpl implements AlarmQueryRepository {
                         )
                 )
                 .from(alarm)
-                .innerJoin(missionObject).on(alarm.missionObject.id.eq(missionObject.id))
+                .join(alarm.missionObject, missionObject)
                 .where(
                         alarm.user.id.eq(userId)
+                                .and(alarm.isDeleted.eq(false))
+                                .and(alarm.isActivated.eq(true))
+                                .and(alarmTimeGoe(now.toLocalTime()))
                                 .and(isDayOrOneTimeAlarm(now))
                 )
                 .orderBy(
@@ -55,8 +58,7 @@ public class AlarmQueryRepositoryImpl implements AlarmQueryRepository {
     @LogExecutionTime
     private BooleanExpression isDayOrOneTimeAlarm(LocalDateTime now) {
         return isDayAlarm(now.getDayOfWeek())
-                .or(isOneTimeAlarm())
-                .and(isActiveAlarm(now.toLocalTime()));
+                .or(isOneTimeAlarm());
     }
 
     private BooleanExpression isDayAlarm(DayOfWeek dayOfWeek) {
@@ -88,11 +90,5 @@ public class AlarmQueryRepositoryImpl implements AlarmQueryRepository {
                 .and(alarm.friday.eq(false))
                 .and(alarm.saturday.eq(false))
                 .and(alarm.sunday.eq(false));
-    }
-
-    private BooleanExpression isActiveAlarm(LocalTime now) {
-        return alarm.isActivated.eq(true)
-                .and(alarm.isDeleted.eq(false))
-                .and(alarmTimeGoe(now));
     }
 }

--- a/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
+++ b/src/main/java/com/wakeUpTogetUp/togetUp/api/alarm/repository/AlarmRepository.java
@@ -35,17 +35,17 @@ public interface AlarmRepository extends JpaRepository<Alarm, Integer>, AlarmQue
     @LogExecutionTime
     @Query("SELECT new com.wakeUpTogetUp.togetUp.api.alarm.controller.dto.response.AlarmSimpleRes("
             + "a.id, "
-            + "a.missionObject.icon, "
+            + "mo.icon, "
             + "ml.createdAt, "
             + "a.name, "
             + "mo.kr, "
             + "a.room.id) "
             + "FROM Alarm a "
-            + "JOIN MissionObject mo ON mo.id = a.missionObject.id "
-            + "JOIN MissionLog ml ON a.id = ml.alarm.id "
+            + "INNER JOIN MissionLog ml ON a.id = ml.alarm.id "
+            + "INNER JOIN MissionObject mo ON mo.id = a.missionObject.id "
             + "WHERE a.user.id = :userId "
             + "AND  ml.createdAt >= :baseTime "
-            + "ORDER BY a.alarmTime ASC, a.id ASC")
+            + "ORDER BY ml.createdAt ASC, a.id ASC")
     List<AlarmSimpleRes> findAllUserAlarmsWithTodayLog(@Param("userId") Integer userId, @Param("baseTime") LocalDateTime baseTime);
 
     @Query("SELECT a.missionObject FROM Alarm a WHERE a.room.id = :roomId ")


### PR DESCRIPTION
## ☀️ 작업 사항

저번 알람 타임라인 중복 에러를 해결할 때 중복으로 보이는 것을 막기 위해 보여지는 알람 시간을 미션을 수행한 시간으로 수정했습니다.
하지만 여전히 정렬이 alarm time 기준으로 되어 있어 타임라인의 순서가 섞이는 에러가 있었습니다.

따라서 현재 시간 이전의 타임라인에 대해서는 미션 수행 시간으로 정렬하여 해당 에러를 해결했습니다.

또한 프레임워크 숙련도 이슈로 mission object 테이블이 cross join되고 있는 것을 발견했습니다.
부모 엔티티에서 필드를 가져오는 것과 조인한 결과에서 가져오는 두 가지 방식을 혼용하고 있었기 때문에 cross join이 발생했습니다.

명시적으로 조인한 결과에서 가져오는 방식으로 통일하여 같은 테이블이지만 다른 2개의 테이블을 cross join하는 것을 방지했습니다.
