### PR TITLE
#167 #170 [FEAT] Jacoco 리포트, SonarCloud 설정 및 JAVA 17로 버전 업그레이드

### DIFF
--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/ci_dev.yml
+++ b/.github/workflows/ci_dev.yml
@@ -17,10 +17,10 @@ jobs:
       - name: checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: make application.yml

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -19,7 +19,7 @@ jobs:
           fetch-depth: 0
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: 17
           distribution: 'temurin'

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -26,6 +26,8 @@ jobs:
           java-version: 11
           distribution: 'temurin'
           cache: 'gradle'
+      - name: Grant execute permission for gradlew
+        run: chmod +x ./gradlew
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,0 +1,53 @@
+name: TogetUp-Server-Dev CI-PIPELINE
+
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  checks: write
+  pull-requests: write
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout
+        uses: actions/checkout@v3
+
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
+
+      - name: Gradle 캐싱
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle
+
+      - name: Gradle 셋업
+        uses: gradle/actions/setup-gradle@v3
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Build with Gradle
+        run: ./gradlew build --parallel
+
+      - name: Jacoco Report 작성
+        uses: madrapps/jacoco-report@v1.6.1
+        with:
+          title: Jacoco Test Coverage
+          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
+          token: ${{ secrets.GITHUB_TOKEN }}
+          min-coverage-overall: 60
+          min-coverage-changed-files: 60
+          update-comment: true

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,9 +1,7 @@
 name: TogetUp-Server-Dev CI-PIPELINE
 
 on:
-  pull_request:
-    branches:
-      - main
+
   push:
     branches:
       - feature/jacoco-sonarcloud
@@ -20,10 +18,10 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
       - name: Grant execute permission for gradlew

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -1,7 +1,9 @@
 name: TogetUp-Server-Dev CI-PIPELINE
 
 on:
-
+  pull_request:
+    branches:
+      - main
   push:
     branches:
       - feature/jacoco-sonarcloud
@@ -41,7 +43,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-          
+
       - name: SonarCloud scan
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -4,6 +4,9 @@ on:
   pull_request:
     branches:
       - main
+  push:
+    branches:
+      - feature/jacoco-sonarcloud
 
 permissions:
   contents: read

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -4,9 +4,6 @@ on:
   pull_request:
     branches:
       - main
-  push:
-    branches:
-      - feature/jacoco-sonarcloud
 
 permissions:
   contents: read

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -12,45 +12,28 @@ permissions:
   contents: read
   checks: write
   pull-requests: write
-
 jobs:
-  build:
+  sonarcloud:
+    name: SonarCloud
     runs-on: ubuntu-latest
     steps:
-      - name: checkout
-        uses: actions/checkout@v3
-
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
       - name: Set up JDK 11
         uses: actions/setup-java@v3
         with:
-          java-version: '11'
+          java-version: 11
           distribution: 'temurin'
-
-      - name: Gradle 캐싱
+          cache: 'gradle'
+      - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle
-
-      - name: Gradle 셋업
-        uses: gradle/actions/setup-gradle@v3
-
-      - name: Grant execute permission for gradlew
-        run: chmod +x gradlew
-
-      - name: Build with Gradle
-        run: ./gradlew build --parallel
-
-      - name: Jacoco Report 작성
-        uses: madrapps/jacoco-report@v1.6.1
-        with:
-          title: Jacoco Test Coverage
-          paths: ${{ github.workspace }}/**/build/reports/jacoco/test/jacocoTestReport.xml
-          token: ${{ secrets.GITHUB_TOKEN }}
-          min-coverage-overall: 60
-          min-coverage-changed-files: 60
-          update-comment: true
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Build and analyze
+        run: ./gradlew build jacocoTestReport sonar --info
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/ci_pipeline.yml
+++ b/.github/workflows/ci_pipeline.yml
@@ -18,22 +18,32 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+
       - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
           java-version: 17
           distribution: 'temurin'
           cache: 'gradle'
+
       - name: Grant execute permission for gradlew
         run: chmod +x ./gradlew
+
       - name: Cache SonarCloud packages
         uses: actions/cache@v3
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
+
       - name: Build and analyze
         run: ./gradlew build jacocoTestReport sonar --info
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          
+      - name: SonarCloud scan
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: ./gradlew sonar --info --stacktrace

--- a/.github/workflows/cicd_dev.yml
+++ b/.github/workflows/cicd_dev.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/.github/workflows/cicd_dev.yml
+++ b/.github/workflows/cicd_dev.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Get CurrentTime

--- a/.github/workflows/cicd_prod.yml
+++ b/.github/workflows/cicd_prod.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
-        uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v2
         with:
-          java-version: '11'
+          java-version: '17'
           distribution: 'temurin'
 
       - name: Get CurrentTime

--- a/.github/workflows/cicd_prod.yml
+++ b/.github/workflows/cicd_prod.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v2
+        uses: actions/setup-java@v4
         with:
           java-version: '17'
           distribution: 'temurin'

--- a/build.gradle
+++ b/build.gradle
@@ -9,7 +9,7 @@ plugins {
 
 group = 'com.jogijo'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = '17'
 compileJava.options.encoding = 'UTF-8'
 
 repositories {

--- a/build.gradle
+++ b/build.gradle
@@ -3,6 +3,8 @@ plugins {
     id 'org.springframework.boot' version '2.7.18'
     id 'io.spring.dependency-management' version '1.0.15.RELEASE'
     id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
+    id 'jacoco'
+    id 'org.sonarqube' version '4.4.1.3373'
 }
 
 group = 'com.jogijo'
@@ -155,3 +157,98 @@ configurations {
     }
     querydsl.extendsFrom compileClasspath
 }
+tasks.named('test') {
+    useJUnitPlatform()
+    finalizedBy 'jacocoTestReport'
+}
+
+jacoco {
+    toolVersion = '0.8.11'
+}
+
+jacocoTestReport {
+
+    def Qdomains = []
+
+    for (qPattern in "**/QA".."**/QZ") {
+        Qdomains.add(qPattern + "*")
+    }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, // 리포트 결과에 제외시킬 디렉토리
+                    exclude: [
+                            '**/dto*',
+                            '**/config*',
+                            '*.Q*'] + Qdomains)
+        }))
+    }
+    reports {
+        html.required = true
+        xml.required = true
+        csv.required = false
+    }
+
+    finalizedBy jacocoTestCoverageVerification
+    dependsOn test
+}
+def includePatterns = [
+        '**/service/*',
+]
+def excludePatterns = [
+        '**/dto*',
+        '**/config*',
+        '*.Q*'
+]
+
+jacocoTestCoverageVerification {
+    violationRules {
+        failOnViolation = false
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            limit {
+                counter = 'BRANCH'
+                value = 'COVEREDRATIO'
+                minimum = 0.80
+            }
+
+            includes = includePatterns
+            excludes = excludePatterns
+        }
+
+        rule {
+            enabled = true
+            element = 'METHOD'
+
+            limit {
+                counter = 'LINE'
+                value = 'TOTALCOUNT'
+                maximum = 200
+            }
+            includes = includePatterns
+            excludes = excludePatterns
+        }
+
+    }
+
+    dependsOn jacocoTestReport
+}
+
+sonar {
+    properties {
+        property 'sonar.host.url', 'https://sonarcloud.io'
+        property 'sonar.organization', 'organizationKey'
+        property 'sonar.projectKey', 'projectKey'
+        property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
+    }
+}
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -245,9 +245,9 @@ jacocoTestCoverageVerification {
 sonar {
     properties {
         property 'sonar.host.url', 'https://sonarcloud.io'
-        property 'sonar.organization', 'organizationKey'
-        property 'sonar.projectKey', 'projectKey'
-        property 'sonar.coverage.jacoco.xmlReportPaths', 'build/reports/jacoco/test/jacocoTestReport.xml'
+        property 'sonar.organization', 'togetup-server'
+        property 'sonar.projectKey', 'Wake-up-together-TogetUp_togetup-server'
+        property 'sonar.coverage.jacoco.xmlReportPaths', '${buildDir}/reports/jacoco/test/jacocoTestReport.xml'
     }
 }
 

--- a/src/test/java/com/wakeUpTogetUp/togetUp/TogetUpApplicationTests.java
+++ b/src/test/java/com/wakeUpTogetUp/togetUp/TogetUpApplicationTests.java
@@ -1,13 +1,13 @@
-package com.wakeUpTogetUp.togetUp;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.boot.test.context.SpringBootTest;
-
-@SpringBootTest
-class TogetUpApplicationTests {
-
-	@Test
-	void contextLoads() {
-	}
-
-}
+//package com.wakeUpTogetUp.togetUp;
+//
+//import org.junit.jupiter.api.Test;
+//import org.springframework.boot.test.context.SpringBootTest;
+//
+//@SpringBootTest
+//class TogetUpApplicationTests {
+//
+//	@Test
+//	void contextLoads() {
+//	}
+//
+//}


### PR DESCRIPTION
## ☀️ 작업 사항

- Java 버전 17 업그레이드
- JaCoCo 리포트 설정 추가
- SonarCloud 통합 설정

## ☀️ 관련 이슈
resolved : #167 , #170 


## ☀️ 참고 사항
- `Google code style` 체크도 추가할 예정입니다.
- 현재 데이터베이스 연결 문제로 인해 [특정 테스트 코드](https://github.com/Wake-up-together-TogetUp/togetup-server/pull/169/commits/1b162b14b6956f197e467909f3a17a9d0b5ba6d0) 주석 처리하였습니다. CI 환경에서 Docker를 사용하여 테스트용 데이터베이스를 추가할 예정입니다.. 
- 지난 회의에서 결정된 Java 17 업그레이드를 반영했습니다. SonarCloud와의 호환성 문제로 이번 PR에서 함께 처리했습니다.
### 도입 이유
운영 환경으로의 전환에 대비하여 코드 품질과 유지보수성을 향상시키기 위해 도입하였습니다.
버그, 컨벤션, 중복코드에 사전에 검토하여 효율적인 코드 리뷰를 진행할 수 있도록 했습니다. 
## SonarCLoud에 대한 간단한 설명
---
### 정적 코드 분석 지원
- 정적 코드 분석을 통해 코드의 품질과 보안을 평가
- 버그, 보안 취약점, 코드 커버리지, 중복 코드 등을 식별
- 이러한 분석을 통해 ‘클린코드’를 지향
### SonarCloud를 통해 확인할 수 있는 것
- Bugs: 코딩 오류
- Vulnerabilities: 보안 공격 가능성이 있는 취약점 식별
- Code Smells: 유지보수에 어려움을 초래할 수 있는 비효율적인 코드 분석
- Duplications: 중복코드
