### PR TITLE
[ENV] 개발 환경에 필요한 경우 배포할 수 있는 옵션 추가

### DIFF
--- a/.github/workflows/cicd_dev.yml
+++ b/.github/workflows/cicd_dev.yml
@@ -2,6 +2,7 @@ name: TogetUp-Server-Dev CI/CD
 on:
   push:
     branches: [ "main" ]
+  workflow_dispatch:
 
 env:
   S3_BUCKET_NAME: togetup-storage


### PR DESCRIPTION
## ☀️ 작업 사항

원활한 마이그레이션을 위해 push뿐만 아니라 개발 환경에 필요한 경우 배포할 수 있는 옵션을 추가했습니다.

## ☀️ 참고 사항
https://docs.github.com/ko/actions/managing-workflow-runs-and-deployments/managing-workflow-runs/manually-running-a-workflow
https://docs.github.com/ko/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_dispatch